### PR TITLE
refactor(mcp): drop non-null assertions via requireEvonHost

### DIFF
--- a/src/api-client.ts
+++ b/src/api-client.ts
@@ -2,7 +2,7 @@
  * API client for Evon Smart Home
  */
 
-import { EVON_HOST, EVON_USERNAME, EVON_PASSWORD, validateConfig } from "./config.js";
+import { EVON_HOST, EVON_USERNAME, EVON_PASSWORD, requireEvonHost } from "./config.js";
 import { API_TIMEOUT_MS, CANONICAL_TO_HTTP_METHOD, TOKEN_VALIDITY_DAYS } from "./constants.js";
 import { performLogin } from "./auth.js";
 import type { ApiResponse } from "./types.js";
@@ -30,9 +30,7 @@ export async function login(): Promise<string> {
 }
 
 async function doLogin(): Promise<string> {
-  validateConfig();
-  // validateConfig() above ensures EVON_HOST is set
-  const token = await performLogin(EVON_HOST!, EVON_USERNAME, EVON_PASSWORD);
+  const token = await performLogin(requireEvonHost(), EVON_USERNAME, EVON_PASSWORD);
   currentToken = token;
   tokenExpiry = Date.now() + TOKEN_VALIDITY_DAYS * 24 * 60 * 60 * 1000;
   return token;

--- a/src/config.ts
+++ b/src/config.ts
@@ -43,14 +43,15 @@ export const EVON_PASSWORD =
   : encodePassword(EVON_USERNAME, EVON_PASSWORD_RAW);
 
 /**
- * Validate that required environment variables are set.
- * Call this before making API requests rather than at import time.
+ * Return EVON_HOST, throwing if it's unset. Call this before making API
+ * requests rather than validating at import time.
  */
-export function validateConfig(): void {
+export function requireEvonHost(): string {
   if (!EVON_HOST) {
     throw new Error(
       "EVON_HOST environment variable is not set. " +
         "Set it to your Evon system URL (e.g., http://192.168.1.x).",
     );
   }
+  return EVON_HOST;
 }

--- a/src/ws-client.ts
+++ b/src/ws-client.ts
@@ -22,7 +22,7 @@
  */
 
 import { WebSocket } from "ws";
-import { EVON_HOST, EVON_USERNAME, EVON_PASSWORD, validateConfig } from "./config.js";
+import { EVON_USERNAME, EVON_PASSWORD, requireEvonHost } from "./config.js";
 import { API_TIMEOUT_MS, WS_DEVICE_CLASSES } from "./constants.js";
 import { performLogin } from "./auth.js";
 
@@ -137,9 +137,7 @@ export class EvonWsClient {
   private wsHost: string;
 
   constructor(host?: string) {
-    if (!host) validateConfig();
-    // validateConfig() above ensures EVON_HOST is set when no host arg
-    this.host = host || EVON_HOST!;
+    this.host = host ?? requireEvonHost();
     this.wsHost = this.host.replace("http://", "ws://").replace("https://", "wss://");
   }
 


### PR DESCRIPTION
## Summary

- Replaces `validateConfig(): void` with `requireEvonHost(): string` in `src/config.ts`
- Updates both callers (`src/api-client.ts`, `src/ws-client.ts`) to use the returned value, dropping `EVON_HOST!` non-null assertions
- Clears the 2 pre-existing `@typescript-eslint/no-non-null-assertion` lint warnings

## Why

The old `validateConfig()` threw if `EVON_HOST` was unset but didn't narrow the type, so each caller still had to write `EVON_HOST!`. ESLint flagged both uses (`src/api-client.ts:35`, `src/ws-client.ts:142`). Returning the validated string from one function is the idiomatic fix and makes the non-null guarantee explicit at the call site.

## Diff shape

```
 src/api-client.ts | 6 ++----
 src/config.ts     | 7 ++++---
 src/ws-client.ts  | 6 ++----
 3 files changed, 8 insertions(+), 11 deletions(-)
```

Net: removes 3 lines more than it adds, including 2 `!` assertions and 2 `// validateConfig() above ensures EVON_HOST is set` comments.

## Behavior

Unchanged. Same error message, same throw timing (at first login / ws-client construction with no host arg). Existing tests that set `process.env.EVON_HOST` before re-importing the module continue to work.

## Test plan

- [x] `npm run lint` — 0 warnings (was 2)
- [x] `npm run build` — clean
- [x] `npm test` — 14/14 pass
- [x] Live smoke test against Evon at 192.168.1.4 — `list_home_states` returns current state

🤖 Generated with [Claude Code](https://claude.com/claude-code)